### PR TITLE
Fix access_token for the facebook network

### DIFF
--- a/lib/networks/facebook.php
+++ b/lib/networks/facebook.php
@@ -102,8 +102,8 @@
 						curl_close($ch);
 						
 						if(!empty($response)){
-							list($dummy, $token) = explode("=", $response);
-							
+							list($token, $dummy) = preg_split('/access_token=([a-zA-Z0-9]+)/', $response, 2,  PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
 							if(!empty($token)){
 								$result = $token;
 							}


### PR DESCRIPTION
Socialink is failing for facebook accounts in function socialink_facebook_get_access_token(). This function extracts the token as the substring to the right of the '=' character. However, there is also a '&expires=...' parameter at the end of the facebook response that must also be removed to get the token.
This patch fixes it.
